### PR TITLE
Minimize/Maximize icon revamp

### DIFF
--- a/content.js
+++ b/content.js
@@ -460,9 +460,13 @@ class AmritaAttendanceTracker {
               <span class="ml-text">ML</span>
             </label>
           </div>
-          <button id="refresh-btn" class="control-btn" title="Refresh Data">↻</button>
-          <button id="minimize-btn" class="control-btn" title="Minimize">−</button>
-          <button id="close-btn" class="control-btn" title="Close">×</button>
+          <button id="close-btn" class="control-btn close" title="Close">×</button>
+          <button id="minimize-btn" class="control-btn minimize" title="Minimize">−</button>
+          <button id="refresh-btn" class="control-btn refresh" title="Refresh Data">
+            <svg viewBox="0 0 24 24" width="14" height="14">
+              <path fill="currentColor" d="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z" />
+            </svg>
+          </button>
         </div>
       </div>
       
@@ -521,8 +525,21 @@ class AmritaAttendanceTracker {
     minimizeBtn.addEventListener('click', () => {
       this.widget.classList.toggle('minimized');
       const isMinimized = this.widget.classList.contains('minimized');
-      minimizeBtn.textContent = isMinimized ? '+' : '−';
-      minimizeBtn.title = isMinimized ? 'Maximize' : 'Minimize';
+      
+      if (isMinimized) {
+        // Change to Maximize icon (User-provided Custom Triangles)
+        minimizeBtn.innerHTML = `
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none">
+            <path d="M5 5H13L5 13V5Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+            <path d="M19 19H11L19 11V19Z" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+          </svg>
+        `;
+        minimizeBtn.title = 'Maximize';
+      } else {
+        // Change back to Minimize icon (Minus)
+        minimizeBtn.innerHTML = '−';
+        minimizeBtn.title = 'Minimize';
+      }
     });
 
     closeBtn.addEventListener('click', () => {

--- a/content.js
+++ b/content.js
@@ -507,6 +507,9 @@ getBunkContent(subject) {
 
     minimizeBtn.addEventListener('click', () => {
       this.widget.classList.toggle('minimized');
+      const isMinimized = this.widget.classList.contains('minimized');
+      minimizeBtn.textContent = isMinimized ? '+' : '−';
+      minimizeBtn.title = isMinimized ? 'Maximize' : 'Minimize';
     });
 
     closeBtn.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -229,22 +229,52 @@
 }
 
 .control-btn {
-  background: rgba(255, 255, 255, 0.2) !important;
+  background: none !important;
   border: none !important;
   color: white !important;
-  width: 28px !important;
-  height: 28px !important;
+  width: 24px !important;
+  height: 24px !important;
   border-radius: 50% !important;
   cursor: pointer !important;
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
-  font-size: 14px !important;
-  transition: all 0.3s ease !important;
+  font-size: 16px !important;
+  font-weight: 800 !important;
+  transition: all 0.2s ease !important;
+  position: relative !important;
+}
+
+.control-btn svg {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+}
+
+.control-btn.close {
+  background-color: #ff5f56 !important;
+  border: 0.5px solid #e0443e !important;
+  color: #4b0001 !important;
+}
+
+.control-btn.minimize {
+  background-color: #ffbd2e !important;
+  border: 0.5px solid #dea123 !important;
+  color: #995700 !important;
+}
+
+.control-btn.refresh {
+  background-color: #27c93f !important;
+  border: 0.5px solid #1aab29 !important;
+  color: #006500 !important;
 }
 
 .control-btn:hover {
-  background: rgba(255, 255, 255, 0.3) !important;
+  filter: brightness(1.1) !important;
+}
+
+.control-btn:active {
+  filter: brightness(0.9) !important;
 }
 
 /* Smooth transitions for subject cards */


### PR DESCRIPTION
### Summary
This PR updates the widget UI to include the requested MacOS-style control buttons (Minimize, Close, Refresh) and fixes the minimize icon toggle logic.

### Changes
- **MacOS-style Buttons:** Replaced standard buttons with MacOS-inspired colored dots for a cleaner look.
- **Icon Logic Fix:** The minimize button now correctly switches to a `+` icon when the widget is minimized (previously stayed as `-`).

### Screenshots
**Before:**

<img width="523" height="188" alt="image" src="https://github.com/user-attachments/assets/d192ee6b-1209-4f95-b5d6-2b63cfcb9538" />

<img width="704" height="261" alt="image" src="https://github.com/user-attachments/assets/eed63670-2459-46d0-81dc-b8c0f62551d7" />

**After (MacOS Buttons & Fixed Toggle):**

<img width="513" height="697" alt="image" src="https://github.com/user-attachments/assets/64da2eb0-5ff7-4a0f-8b29-24cf3cd898ba" />


<img width="589" height="128" alt="image" src="https://github.com/user-attachments/assets/c350386e-f68f-4985-a0a7-d95af76d4872" />



### Related Issue
Closes #18
