### PR TITLE
fix(popup): normalize saved minimum attendance value🍉

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -31,7 +31,8 @@ class PopupManager {
           if (result.attendanceData && result.attendanceData.length > 0) {
             this.attendanceData = result.attendanceData;
             this.includeMedical = result.includeMedical || false;
-            this.minAttendance = result.minAttendance || 75;
+            const storedMinAttendance = Number(result.minAttendance);
+            this.minAttendance = Number.isFinite(storedMinAttendance) ? storedMinAttendance : 75;
             this.renderData();
           }
           resolve();
@@ -104,7 +105,7 @@ class PopupManager {
       return;
     }
 
-    const minAttendance = this.minAttendance || 75;
+    const minAttendance = Number.isFinite(this.minAttendance) ? this.minAttendance : 75;
 
     subjectList.innerHTML = this.attendanceData.map(subject => {
       const bunkContent = this.getBunkContent(subject);


### PR DESCRIPTION
## Summary

This PR normalizes the saved minimum attendance value in the popup before using it.

## Changes

- Normalize the value retrieved from Chrome storage before assigning it.
- Fall back to the default threshold only when the stored value is not a valid number.
- Keep threshold handling consistent with the content script.

## Why

The content script already validates the stored attendance threshold before using it. Applying the same validation in the popup ensures both components interpret the stored value consistently and prevents issues if the stored value is not a valid number.

## Testing

- Verified `popup.js` parses successfully using `node --check`.
- Confirmed the popup continues to display the configured attendance threshold correctly.